### PR TITLE
Update .gitattributes to fix cloning bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
-*.mp3 filter=lfs diff=lfs merge=lfs -text
-*.wav filter=lfs diff=lfs merge=lfs -text
-
 *.pbxproj merge=union
 *.storyboard  merge=union


### PR DESCRIPTION
Cloning the repo to a local machine that already had Git LFS enabled ran
into errors because LFS was trying to download files that don't exist
anymore.

The fix was to tell Git LFS to stop looking for those files.